### PR TITLE
Canonicalize override-file platform ids at pack time

### DIFF
--- a/docs/BundlerDiagnosticCodes.md
+++ b/docs/BundlerDiagnosticCodes.md
@@ -9,7 +9,7 @@ Every emitted message is prefixed with the code's short **Name** (e.g. `Platform
 
 - **Name:** Platform fetch failed
 - **Level**: Error
-- **Meaning:** Bundler-side platform error (HTTP failure, GraphQL error, etc.) — message is the underlying `MaintenanceFeeException`.
+- **Meaning:** Bundler-side platform error (HTTP failure, GraphQL error, an override file naming an unknown platform, etc.) — message is the underlying `MaintenanceFeeException`.
 - **Syntax:** `{exception.Message}`
 - **Example:** `Polar HTTP 500: {"detail":"server error"}`
 

--- a/src/SponsorCheck.Tests/BundleSponsorListTaskTests.cs
+++ b/src/SponsorCheck.Tests/BundleSponsorListTaskTests.cs
@@ -253,6 +253,73 @@ public class BundleSponsorListTaskTests
         }
     }
 
+    [Test]
+    public async Task OverrideList_NormalizesPlatformIdCasing()
+    {
+        // Override entries can carry arbitrary platform-id casing. SponsorHasher does NOT case-fold
+        // the platform id, and the verifier always hashes with the canonical literal ("GitHubSponsors"),
+        // so the bundler must canonicalize the id — otherwise the bundled hash could never match a
+        // consumer and every build would fail SC007 despite the override packing cleanly.
+        using var dir = new TempDirectory();
+        var template = BuildTemplate(dir);
+        var override_ = WriteOverride(dir, """[{"platform":"githubsponsors","account":"alice"}]""");
+        var task = new BundleSponsorListTask
+        {
+            BuildEngine = new StubBuildEngine(),
+            GitHubSponsorsAccountFromRef = "acmecorp",
+            VerifierTargetsTemplatePath = template,
+            ThePackageId = "MyOssLib",
+            OverrideListPath = override_,
+            OutputHashListPath = Path.Combine(dir, "SponsorHashes.txt"),
+            OutputVerifierTargetsPath = Path.Combine(dir, "MyOssLib.targets"),
+            OutputPackDatePath = Path.Combine(dir, "PackDate.txt"),
+            OutputAuthorAccountsPath = Path.Combine(dir, "AuthorAccounts.txt"),
+            OutputSeverityOverridesPath = Path.Combine(dir, "SeverityOverrides.txt"),
+            OutputMessageOverridesPath = Path.Combine(dir, "MessageOverrides.json"),
+            OutputLandingUrlPath = Path.Combine(dir, "LandingUrl.txt"),
+            OutputExemptionsPath = Path.Combine(dir, "Exemptions.json")
+        };
+
+        await Assert.That(task.Execute()).IsTrue();
+        var lines = await File.ReadAllLinesAsync(task.OutputHashListPath);
+        await Assert.That(lines.Length).IsEqualTo(1);
+        // Hash matches the canonical-cased platform id the verifier computes, not the raw "githubsponsors".
+        await Assert.That(lines[0]).IsEqualTo(SponsorHasher.Hash("GitHubSponsors", "alice"));
+    }
+
+    [Test]
+    public async Task OverrideList_UnknownPlatform_FailsWithSC100()
+    {
+        // A platform id the registry doesn't recognize would otherwise bundle a hash no verifier can
+        // ever match (the verifier only hashes the three known platform literals). Fail at pack time
+        // rather than silently shipping dead hashes.
+        using var dir = new TempDirectory();
+        var template = BuildTemplate(dir);
+        var engine = new StubBuildEngine();
+        var override_ = WriteOverride(dir, """[{"platform":"GitHub","account":"alice"}]""");
+        var task = new BundleSponsorListTask
+        {
+            BuildEngine = engine,
+            GitHubSponsorsAccountFromRef = "acmecorp",
+            VerifierTargetsTemplatePath = template,
+            ThePackageId = "MyOssLib",
+            OverrideListPath = override_,
+            OutputHashListPath = Path.Combine(dir, "SponsorHashes.txt"),
+            OutputVerifierTargetsPath = Path.Combine(dir, "MyOssLib.targets"),
+            OutputPackDatePath = Path.Combine(dir, "PackDate.txt"),
+            OutputAuthorAccountsPath = Path.Combine(dir, "AuthorAccounts.txt"),
+            OutputSeverityOverridesPath = Path.Combine(dir, "SeverityOverrides.txt"),
+            OutputMessageOverridesPath = Path.Combine(dir, "MessageOverrides.json"),
+            OutputLandingUrlPath = Path.Combine(dir, "LandingUrl.txt"),
+            OutputExemptionsPath = Path.Combine(dir, "Exemptions.json")
+        };
+
+        await Assert.That(task.Execute()).IsFalse();
+        await Assert.That(engine.Errors).HasSingleItem();
+        await Assert.That(engine.Errors[0].Code).IsEqualTo("SC100");
+        await Assert.That(engine.Errors[0].Message).Contains("Unknown sponsorship platform 'GitHub'");
+    }
+
     static IReadOnlyDictionary<string, string> Secrets(params (string key, string value)[] entries)
     {
         var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);

--- a/src/SponsorCheck/BundleSponsorListTask.cs
+++ b/src/SponsorCheck/BundleSponsorListTask.cs
@@ -324,7 +324,21 @@ public sealed class BundleSponsorListTask :
     IReadOnlyList<SponsorEntry> FetchFromOverride()
     {
         Log.LogMessage(MessageImportance.High, $"SponsorCheck: using sponsor override list '{OverrideListPath}'.");
-        return SponsorOverrideFile.Read(OverrideListPath);
+        // Canonicalize each entry's platform id through the registry (and reject unknown platforms).
+        // SponsorHasher does not case-fold the platform id, and the verifier always hashes with the
+        // canonical literal ("GitHubSponsors" etc.), so an override entry like "githubsponsors" would
+        // otherwise bundle a hash no consumer could ever match — packing cleanly, then failing every
+        // consumer with SC007. The API path never hits this because it already resolves canonical ids
+        // via PlatformRegistry; Get throws MaintenanceFeeException (SC100) for an unknown platform.
+        var entries = SponsorOverrideFile.Read(OverrideListPath);
+        var normalized = new List<SponsorEntry>(entries.Count);
+        foreach (var entry in entries)
+        {
+            var platform = PlatformRegistry.Get(entry.Platform);
+            normalized.Add(new(platform.Id, entry.Account));
+        }
+
+        return normalized;
     }
 
     async Task<IReadOnlyList<SponsorEntry>> FetchFromPlatformsAsync(Dictionary<string, string> enabled)


### PR DESCRIPTION
An override entry like "githubsponsors" packed cleanly but bundled a hash no consumer could match: SponsorHasher does not case-fold the platform id and the verifier always hashes the canonical literal, so every build failed SC007. FetchFromOverride now routes each entry through PlatformRegistry.Get, normalizing the id and rejecting unknown platforms with SC100 — mirroring the API path. Adds regression tests for both cases.