### PR TITLE
Resolve platform HttpClient lazily so verifier builds skip it

### DIFF
--- a/src/SponsorCheck/Platforms/GitHubSponsorsPlatform.cs
+++ b/src/SponsorCheck/Platforms/GitHubSponsorsPlatform.cs
@@ -1,4 +1,4 @@
-public sealed class GitHubSponsorsPlatform(HttpClient client) :
+public sealed class GitHubSponsorsPlatform(HttpClient? client = null) :
     ISponsorshipPlatform
 {
     const string endpoint = "https://api.github.com/graphql";
@@ -46,10 +46,10 @@ public sealed class GitHubSponsorsPlatform(HttpClient client) :
 
     public static readonly TimeSpan OneTimeWindow = TimeSpan.FromDays(30);
 
-    public GitHubSponsorsPlatform() :
-        this(HttpClientFactory.Get())
-    {
-    }
+    // Resolve the shared HttpClient lazily. PlatformRegistry constructs all three platforms just for
+    // id→URL/name mapping on the verifier's hot path; building them must not allocate an HttpClient.
+    // Only an actual fetch (bundler pack time) touches the network. Tests inject a stub client.
+    HttpClient Client => client ?? HttpClientFactory.Get();
 
     public string Id => "GitHubSponsors";
 
@@ -185,7 +185,7 @@ public sealed class GitHubSponsorsPlatform(HttpClient client) :
 
         request.Headers.Authorization = new("Bearer", token);
 
-        using var response = await client.SendAsync(request, cancel).ConfigureAwait(false);
+        using var response = await Client.SendAsync(request, cancel).ConfigureAwait(false);
         var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
         if (response.IsSuccessStatusCode)
         {

--- a/src/SponsorCheck/Platforms/OpenCollectivePlatform.cs
+++ b/src/SponsorCheck/Platforms/OpenCollectivePlatform.cs
@@ -1,4 +1,4 @@
-public sealed class OpenCollectivePlatform(HttpClient client) : ISponsorshipPlatform
+public sealed class OpenCollectivePlatform(HttpClient? client = null) : ISponsorshipPlatform
 {
     const string endpoint = "https://api.opencollective.com/graphql/v2";
     const int pageLimit = 100;
@@ -16,7 +16,9 @@ public sealed class OpenCollectivePlatform(HttpClient client) : ISponsorshipPlat
         }
         """;
 
-    public OpenCollectivePlatform() : this(HttpClientFactory.Get()) { }
+    // Lazy client — see GitHubSponsorsPlatform.Client: registry construction on the verifier path
+    // must not allocate an HttpClient; only a real fetch touches the network. Tests inject a stub.
+    HttpClient Client => client ?? HttpClientFactory.Get();
 
     public string Id => "OpenCollective";
 
@@ -79,7 +81,7 @@ public sealed class OpenCollectivePlatform(HttpClient client) : ISponsorshipPlat
             request.Headers.Add("Personal-Token", token);
         }
 
-        using var response = await client.SendAsync(request, cancel).ConfigureAwait(false);
+        using var response = await Client.SendAsync(request, cancel).ConfigureAwait(false);
         var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
         if (response.IsSuccessStatusCode)
         {

--- a/src/SponsorCheck/Platforms/PolarPlatform.cs
+++ b/src/SponsorCheck/Platforms/PolarPlatform.cs
@@ -1,9 +1,11 @@
-public sealed class PolarPlatform(HttpClient client) :
+public sealed class PolarPlatform(HttpClient? client = null) :
     ISponsorshipPlatform
 {
     const string baseUrl = "https://api.polar.sh/v1/";
 
-    public PolarPlatform() : this(HttpClientFactory.Get()) { }
+    // Lazy client — see GitHubSponsorsPlatform.Client: registry construction on the verifier path
+    // must not allocate an HttpClient; only a real fetch touches the network. Tests inject a stub.
+    HttpClient Client => client ?? HttpClientFactory.Get();
 
     public string Id => "Polar";
 
@@ -34,7 +36,7 @@ public sealed class PolarPlatform(HttpClient client) :
             var url = $"{baseUrl}subscriptions/?organization_slug={Uri.EscapeDataString(ownerAccount)}&active=true&limit={limit}&page={page}";
             using var request = new HttpRequestMessage(HttpMethod.Get, url);
             request.Headers.Authorization = new("Bearer", token);
-            using var response = await client.SendAsync(request, cancel).ConfigureAwait(false);
+            using var response = await Client.SendAsync(request, cancel).ConfigureAwait(false);
             var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             if (!response.IsSuccessStatusCode)
             {


### PR DESCRIPTION
Each platform's parameterless constructor eagerly called HttpClientFactory.Get(), forcing the shared HttpClient into existence. PlatformRegistry builds all three on first use — which the verifier triggers just for id→URL/name mapping — so every consumer build allocated an HttpClient it never used. Drop the eager constructor (an optional client param covers it) and resolve the shared client lazily via `client ?? HttpClientFactory.Get()`, touched only on an actual fetch at pack time. Injected clients still win for tests; behavior is unchanged.