### PR TITLE
Reuse one SHA256 across the bundler's hash loop

### DIFF
--- a/src/SponsorCheck.Tests/SponsorHasherTests.cs
+++ b/src/SponsorCheck.Tests/SponsorHasherTests.cs
@@ -54,6 +54,36 @@ public class SponsorHasherTests
     }
 
     [Test]
+    public async Task HashAll_MatchesPerEntryHash()
+    {
+        // The batch reuses a single SHA256 across all entries; ComputeHash re-initializes between
+        // calls, so each result must equal the independent per-entry Hash. Covers a mixed-case
+        // account (lowercasing) and a duplicate (identical input mid-batch → identical hash).
+        var entries = new List<SponsorEntry>
+        {
+            new("GitHubSponsors", "alice"),
+            new("GitHubSponsors", "Bob"),
+            new("OpenCollective", "acme-org"),
+            new("Polar", "acme"),
+            new("GitHubSponsors", "alice")
+        };
+
+        var batch = SponsorHasher.HashAll(entries);
+        var perEntry = entries.Select(_ => SponsorHasher.Hash(_.Platform, _.Account)).ToList();
+
+        await Assert.That(batch.Count).IsEqualTo(perEntry.Count);
+        for (var i = 0; i < perEntry.Count; i++)
+        {
+            await Assert.That(batch[i]).IsEqualTo(perEntry[i]);
+        }
+    }
+
+    [Test]
+    public void HashAll_RejectsEmptyAccountInBatch() =>
+        Assert.Throws<ArgumentException>(() =>
+            SponsorHasher.HashAll([new("GitHubSponsors", "alice"), new("Polar", "  ")]));
+
+    [Test]
     public void RejectsEmptyPlatform() =>
         Assert.Throws<ArgumentException>(() => SponsorHasher.Hash("", "alice"));
 

--- a/src/SponsorCheck/BundleSponsorListTask.cs
+++ b/src/SponsorCheck/BundleSponsorListTask.cs
@@ -124,8 +124,7 @@ public sealed class BundleSponsorListTask :
                 entries = FetchFromOverride();
             }
 
-            var hashes = entries
-                .Select(_ => SponsorHasher.Hash(_.Platform, _.Account))
+            var hashes = SponsorHasher.HashAll(entries)
                 .Distinct(StringComparer.Ordinal)
                 .OrderBy(_ => _, StringComparer.Ordinal)
                 .ToList();

--- a/src/SponsorCheck/SponsorHasher.cs
+++ b/src/SponsorCheck/SponsorHasher.cs
@@ -6,6 +6,39 @@ public static class SponsorHasher
 
     public static string Hash(string platformId, string account)
     {
+        Validate(platformId, account);
+        using var sha = SHA256.Create();
+        return HashWith(sha, platformId, account);
+    }
+
+    // Hashes a whole entry list reusing a single SHA256 instance. The bundler hashes one entry per
+    // sponsor, so this avoids a SHA256.Create()/Dispose() per entry. (The static SHA256.HashData
+    // would not help on the shipping netstandard2.0/net472 assembly: there it resolves to the
+    // Polyfill shim, which is itself a per-call SHA256.Create().) ComputeHash re-initializes between
+    // calls, so the batch yields byte-for-byte the same hashes as calling Hash per entry.
+    public static IReadOnlyList<string> HashAll(IReadOnlyList<SponsorEntry> entries)
+    {
+        using var sha = SHA256.Create();
+        var result = new List<string>(entries.Count);
+        foreach (var entry in entries)
+        {
+            Validate(entry.Platform, entry.Account);
+            result.Add(HashWith(sha, entry.Platform, entry.Account));
+        }
+
+        return result;
+    }
+
+    static string HashWith(SHA256 sha, string platformId, string account)
+    {
+        var input = $"{platformId}:{account.Trim().ToLowerInvariant()}";
+        var bytes = Encoding.UTF8.GetBytes(input);
+        var digest = sha.ComputeHash(bytes);
+        return Convert.ToHexStringLower(digest, 0, hashByteLength);
+    }
+
+    static void Validate(string platformId, string account)
+    {
         if (string.IsNullOrWhiteSpace(platformId))
         {
             throw new ArgumentException("platformId required", nameof(platformId));
@@ -15,11 +48,5 @@ public static class SponsorHasher
         {
             throw new ArgumentException("account required", nameof(account));
         }
-
-        var input = $"{platformId}:{account.Trim().ToLowerInvariant()}";
-        var bytes = Encoding.UTF8.GetBytes(input);
-        using var sha = SHA256.Create();
-        var digest = sha.ComputeHash(bytes);
-        return Convert.ToHexStringLower(digest, 0, hashByteLength);
     }
 }


### PR DESCRIPTION
SponsorHasher.Hash created a fresh SHA256 per call and the bundler called it once per sponsor entry. The static SHA256.HashData is no help on the shipping netstandard2.0/net472 assembly — there it binds to the Polyfill shim, itself a per-call SHA256.Create(). Add HashAll, which creates one SHA256 and reuses it for the whole entry list (ComputeHash re-initializes between calls, so output is identical), and point the bundler at it. Hash keeps its per-call path for the verifier's handful of lookups. Adds a test asserting batch hashes equal the per-entry hashes.