### PR TITLE
Share one host and browser across the browser tests, and warm the app…

### DIFF
--- a/src/SponsorCheck.Web.Tests/EndToEndTests.cs
+++ b/src/SponsorCheck.Web.Tests/EndToEndTests.cs
@@ -6,24 +6,12 @@ namespace SponsorCheck.Web.Tests;
 /// </summary>
 public class EndToEndTests
 {
-    static PublishedWizard? wizard;
-
-    [Before(Class)]
-    public static async Task Setup() => wizard = await PublishedWizard.Start();
-
-    [After(Class)]
-    public static async Task Teardown()
-    {
-        if (wizard != null)
-        {
-            await wizard.DisposeAsync();
-        }
-    }
+    static PublishedWizard wizard => PublishedWizard.Shared;
 
     [Test]
     public async Task Boots()
     {
-        var page = await wizard!.NewPage();
+        var page = await wizard.NewPage();
         await page.GotoAsync(wizard.Url());
         await page.WaitForSelectorAsync(".role-cards");
 
@@ -34,7 +22,7 @@ public class EndToEndTests
     [Test]
     public async Task AuthorJourney()
     {
-        var page = await wizard!.NewPage();
+        var page = await wizard.NewPage();
         await page.GotoAsync(wizard.Url());
         await page.ClickAsync("a.role-card[href='author']");
         await page.WaitForSelectorAsync("#packageId");
@@ -62,7 +50,7 @@ public class EndToEndTests
     [Test]
     public async Task ConsumerOwnerJourney()
     {
-        var page = await wizard!.NewPage();
+        var page = await wizard.NewPage();
         await page.GotoAsync(wizard.Url());
         await page.ClickAsync("a.role-card[href='consumer']");
         await page.WaitForSelectorAsync("#packageId");
@@ -95,7 +83,7 @@ public class EndToEndTests
     public async Task DeepLinkToConsumerFlow()
     {
         // Exercises the SPA fallback (404.html / MapFallbackToFile) that GitHub Pages relies on.
-        var page = await wizard!.NewPage();
+        var page = await wizard.NewPage();
         await page.GotoAsync(wizard.Url("/consumer"));
         await page.WaitForSelectorAsync("#packageId");
 

--- a/src/SponsorCheck.Web.Tests/PublishedWizard.cs
+++ b/src/SponsorCheck.Web.Tests/PublishedWizard.cs
@@ -13,6 +13,29 @@ public sealed class PublishedWizard : IAsyncDisposable
     public IBrowser Browser { get; }
     public int Port { get; }
 
+    static PublishedWizard? shared;
+
+    /// <summary>
+    /// One Kestrel host and one Chromium for the whole assembly. Every browser-based test class hangs
+    /// off this: a per-class instance meant two cold WASM boots racing each other on a two-core CI
+    /// agent, and the losers blew Playwright's 30s default before the runtime finished starting.
+    /// </summary>
+    public static PublishedWizard Shared =>
+        shared ?? throw new("PublishedWizard has not been started.");
+
+    [Before(HookType.Assembly)]
+    public static async Task StartShared() => shared = await Start();
+
+    [After(HookType.Assembly)]
+    public static async Task StopShared()
+    {
+        if (shared != null)
+        {
+            await shared.DisposeAsync();
+            shared = null;
+        }
+    }
+
     PublishedWizard(WebApplication app, IPlaywright playwright, IBrowser browser, int port)
     {
         this.app = app;
@@ -75,7 +98,28 @@ public sealed class PublishedWizard : IAsyncDisposable
 
         var playwright = await Playwright.CreateAsync();
         var browser = await playwright.Chromium.LaunchAsync();
-        return new(app, playwright, browser, port);
+        var wizard = new PublishedWizard(app, playwright, browser, port);
+        await wizard.WarmUp();
+        return wizard;
+    }
+
+    /// <summary>
+    /// Boot the app once, serially, before any test runs. The first load downloads and initializes the
+    /// WASM runtime — on a cold CI agent that alone can outlast Playwright's 30s default, and doing it
+    /// concurrently in several pages only makes each one slower. After this the browser's HTTP cache is
+    /// warm, so the pages the tests open start against an already-fetched runtime.
+    /// </summary>
+    async Task WarmUp()
+    {
+        var page = await NewPage();
+        await page.GotoAsync(Url());
+        await page.WaitForSelectorAsync(
+            ".role-cards",
+            new()
+            {
+                Timeout = 120_000
+            });
+        await page.CloseAsync();
     }
 
     public async ValueTask DisposeAsync()

--- a/src/SponsorCheck.Web.Tests/ScreenSnapshotTests.cs
+++ b/src/SponsorCheck.Web.Tests/ScreenSnapshotTests.cs
@@ -9,23 +9,11 @@ namespace SponsorCheck.Web.Tests;
 /// </summary>
 public class ScreenSnapshotTests
 {
-    static PublishedWizard? wizard;
-
-    [Before(Class)]
-    public static async Task Setup() => wizard = await PublishedWizard.Start();
-
-    [After(Class)]
-    public static async Task Teardown()
-    {
-        if (wizard != null)
-        {
-            await wizard.DisposeAsync();
-        }
-    }
+    static PublishedWizard wizard => PublishedWizard.Shared;
 
     static async Task<IPage> Open(string path, string readySelector)
     {
-        var page = await wizard!.NewPage();
+        var page = await wizard.NewPage();
         await page.GotoAsync(wizard.Url(path));
         await page.WaitForSelectorAsync(readySelector);
         return page;


### PR DESCRIPTION
… once

Each browser test class started its own Kestrel host and Chromium, so two cold WASM boots raced on a two-core CI agent and the losers exceeded Playwright default 30s timeout. The host and browser are now assembly-scoped, and Start boots the app once with a generous timeout so the tests open pages against an already-fetched runtime.