### PR TITLE
Scope a verifier's properties to its package

### DIFF
--- a/IntegrationTests/IntegrationTests/AuthorPackTests.cs
+++ b/IntegrationTests/IntegrationTests/AuthorPackTests.cs
@@ -218,7 +218,11 @@ public class AuthorPackTests
         var content = await reader.ReadToEndAsync();
         await Assert.That(content).Contains("VerifySponsorshipTask");
         await Assert.That(content).Contains("$(GitHubSponsorAccount)");
-        await Assert.That(content).Contains("_SponsorCheck_OwnerId>acme<");
+        // Package-scoped: owner mode emits one verifier per package, so an unscoped name would be
+        // shared by every package from this owner — see GeneratedVerifiers_ShareNoPropertyNames.
+        // The scope carries a hash suffix, so match around it rather than pinning the rendered id.
+        await Assert.That(content).Contains("_OwnerId>acme<");
+        await Assert.That(content).Contains("_SponsorCheck_ThePackageOwnerMode_");
         // The license-check task call must not pull from per-package metadata under owner mode.
         await Assert.That(content).DoesNotContain("GitHubFromVer");
         await Assert.That(content).DoesNotContain("IgnoredFromVer");
@@ -533,5 +537,48 @@ public class AuthorPackTests
         await Assert.That(result.ExitCode).IsNotEqualTo(0).Because(result.Combined);
         await Assert.That(result.Combined).Contains("SC106");
         await Assert.That(result.Combined).Contains("Consulting");
+    }
+    [Test]
+    public async Task GeneratedVerifiers_ShareNoPropertyNames()
+    {
+        // MSBuild properties are global and each verifier is imported into the same project, so a
+        // name defined by two of them is written twice and the last import wins for both. Every
+        // property a verifier defines therefore has to be scoped to what it verifies.
+        //
+        // The unscoped ones used to be the paths: a project referencing two SponsorCheck packages
+        // had both verifiers reading one package's sponsor list, exemptions and task assembly. The
+        // same clobbered TasksDir reached the authoring side, where the pack copies
+        // $(TasksDir)netstandard2.0\*.dll into the nupkg — so a package could ship the SponsorCheck
+        // its *dependency* bundled while its own restore was correct, failing only for consumers.
+        // Two owner-mode packages from the same owner: owner mode still emits one verifier per
+        // package, so scoping the paths by owner would leave these two sharing them.
+        var feed = await ThePackageBuilder.EnsureBuiltCombined("ThePackageOwnerMode", "ThePackageOwnerModeTransitive");
+
+        var first = PropertyNames(feed, "ThePackageOwnerMode");
+        var second = PropertyNames(feed, "ThePackageOwnerModeTransitive");
+
+        await Assert.That(first).IsNotEmpty();
+        await Assert.That(second).IsNotEmpty();
+
+        // The run-once guard is the one name they are meant to share: it is what makes N
+        // packages from one owner verify once instead of N times.
+        var shared = first.Intersect(second).ToList();
+        await Assert.That(shared.Count).IsEqualTo(1);
+        await Assert.That(shared[0]).StartsWith("_SponsorCheck_OwnerVerified_");
+    }
+
+    // The property names a package's generated verifier defines.
+    static List<string> PropertyNames(string feed, string packageId)
+    {
+        var nupkg = Directory.GetFiles(feed, $"{packageId}.*.nupkg").Single();
+        using var zip = ZipFile.OpenRead(nupkg);
+        var entry = zip.Entries.Single(_ => _.FullName.EndsWith($"/{packageId}.targets", StringComparison.Ordinal));
+        using var reader = new StreamReader(entry.Open());
+        var targets = reader.ReadToEnd();
+
+        return Regex.Matches(targets, @"<(_SponsorCheck_[A-Za-z0-9_]*)>")
+            .Select(_ => _.Groups[1].Value)
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
     }
 }

--- a/src/SponsorCheck/EmbeddedTemplates/ConsumerVerifier.targets
+++ b/src/SponsorCheck/EmbeddedTemplates/ConsumerVerifier.targets
@@ -1,17 +1,27 @@
 <Project>
 __SC_INNER_IMPORT__
+  <!-- Every property here is scoped to the package it verifies, because this file is imported once per
+       referenced package and MSBuild properties are global. An unscoped name is written by each import in
+       turn and the last one wins for the whole project, so two of these files would share one set
+       of paths: each verifier would read another package's sponsor list, exemptions and task
+       assembly. The task-name collision below is the same problem — this is the rest of it.
+
+       The clobbered TasksDir also reached the *authoring* side. A package whose author references
+       another SponsorCheck package packs `$(TasksDir)netstandard2.0\*.dll` into its own nupkg, so
+       it shipped whichever SponsorCheck the other package bundled — a stale task in a package
+       whose restore was correct, failing only for its consumers. -->
   <PropertyGroup>
-    <_SponsorCheck_ThePackageId>__SC_PACKAGE_ID_RAW__</_SponsorCheck_ThePackageId>
-    <_SponsorCheck_TasksDir>$(MSBuildThisFileDirectory)..\tasks\</_SponsorCheck_TasksDir>
-    <_SponsorCheck_TasksAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(_SponsorCheck_TasksDir)netstandard2.0\SponsorCheck.dll</_SponsorCheck_TasksAssembly>
-    <_SponsorCheck_TasksAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(_SponsorCheck_TasksDir)net472\SponsorCheck.dll</_SponsorCheck_TasksAssembly>
-    <_SponsorCheck_HashListPath>$(MSBuildThisFileDirectory)SponsorCheck.SponsorHashes.txt</_SponsorCheck_HashListPath>
-    <_SponsorCheck_PackDatePath>$(MSBuildThisFileDirectory)SponsorCheck.PackDate.txt</_SponsorCheck_PackDatePath>
-    <_SponsorCheck_AuthorAccountsPath>$(MSBuildThisFileDirectory)SponsorCheck.AuthorAccounts.txt</_SponsorCheck_AuthorAccountsPath>
-    <_SponsorCheck_SeverityOverridesPath>$(MSBuildThisFileDirectory)SponsorCheck.SeverityOverrides.txt</_SponsorCheck_SeverityOverridesPath>
-    <_SponsorCheck_MessageOverridesPath>$(MSBuildThisFileDirectory)SponsorCheck.MessageOverrides.json</_SponsorCheck_MessageOverridesPath>
-    <_SponsorCheck_LandingUrlPath>$(MSBuildThisFileDirectory)SponsorCheck.LandingUrl.txt</_SponsorCheck_LandingUrlPath>
-    <_SponsorCheck_ExemptionsPath>$(MSBuildThisFileDirectory)SponsorCheck.Exemptions.json</_SponsorCheck_ExemptionsPath>
+    <_SponsorCheck___SC_PACKAGE_ID___ThePackageId>__SC_PACKAGE_ID_RAW__</_SponsorCheck___SC_PACKAGE_ID___ThePackageId>
+    <_SponsorCheck___SC_PACKAGE_ID___TasksDir>$(MSBuildThisFileDirectory)..\tasks\</_SponsorCheck___SC_PACKAGE_ID___TasksDir>
+    <_SponsorCheck___SC_PACKAGE_ID___TasksAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(_SponsorCheck___SC_PACKAGE_ID___TasksDir)netstandard2.0\SponsorCheck.dll</_SponsorCheck___SC_PACKAGE_ID___TasksAssembly>
+    <_SponsorCheck___SC_PACKAGE_ID___TasksAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(_SponsorCheck___SC_PACKAGE_ID___TasksDir)net472\SponsorCheck.dll</_SponsorCheck___SC_PACKAGE_ID___TasksAssembly>
+    <_SponsorCheck___SC_PACKAGE_ID___HashListPath>$(MSBuildThisFileDirectory)SponsorCheck.SponsorHashes.txt</_SponsorCheck___SC_PACKAGE_ID___HashListPath>
+    <_SponsorCheck___SC_PACKAGE_ID___PackDatePath>$(MSBuildThisFileDirectory)SponsorCheck.PackDate.txt</_SponsorCheck___SC_PACKAGE_ID___PackDatePath>
+    <_SponsorCheck___SC_PACKAGE_ID___AuthorAccountsPath>$(MSBuildThisFileDirectory)SponsorCheck.AuthorAccounts.txt</_SponsorCheck___SC_PACKAGE_ID___AuthorAccountsPath>
+    <_SponsorCheck___SC_PACKAGE_ID___SeverityOverridesPath>$(MSBuildThisFileDirectory)SponsorCheck.SeverityOverrides.txt</_SponsorCheck___SC_PACKAGE_ID___SeverityOverridesPath>
+    <_SponsorCheck___SC_PACKAGE_ID___MessageOverridesPath>$(MSBuildThisFileDirectory)SponsorCheck.MessageOverrides.json</_SponsorCheck___SC_PACKAGE_ID___MessageOverridesPath>
+    <_SponsorCheck___SC_PACKAGE_ID___LandingUrlPath>$(MSBuildThisFileDirectory)SponsorCheck.LandingUrl.txt</_SponsorCheck___SC_PACKAGE_ID___LandingUrlPath>
+    <_SponsorCheck___SC_PACKAGE_ID___ExemptionsPath>$(MSBuildThisFileDirectory)SponsorCheck.Exemptions.json</_SponsorCheck___SC_PACKAGE_ID___ExemptionsPath>
   </PropertyGroup>
 
   <!-- __SC_TASK_NAME__ renders to the version-scoped task type (VerifySponsorshipTask_<version>).
@@ -22,7 +32,7 @@ __SC_INNER_IMPORT__
        parameter the older task didn't declare. A version-scoped name gives each SponsorCheck release
        its own registration, so every verifier binds to the copy it was generated against. -->
   <UsingTask TaskName="__SC_TASK_NAME__"
-             AssemblyFile="$(_SponsorCheck_TasksAssembly)" />
+             AssemblyFile="$(_SponsorCheck___SC_PACKAGE_ID___TasksAssembly)" />
 
   <!-- Project-reference coverage responders — see ConsumerVerifierOwner.targets for the rationale.
        For per-package mode, transitive consumers can't supply the required <PackageReference>
@@ -31,8 +41,8 @@ __SC_INNER_IMPORT__
           Returns="@(_SponsorCheck_Covered___SC_PACKAGE_ID__)">
     <ItemGroup>
       <_SponsorCheck_Covered___SC_PACKAGE_ID__
-          Include="$(_SponsorCheck_ThePackageId)"
-          Condition="@(PackageReference->AnyHaveMetadataValue('Identity', '$(_SponsorCheck_ThePackageId)'))" />
+          Include="$(_SponsorCheck___SC_PACKAGE_ID___ThePackageId)"
+          Condition="@(PackageReference->AnyHaveMetadataValue('Identity', '$(_SponsorCheck___SC_PACKAGE_ID___ThePackageId)'))" />
     </ItemGroup>
     <MSBuild Projects="@(ProjectReference)"
              Targets="_SponsorCheck_CoversShallow___SC_PACKAGE_ID__"
@@ -46,8 +56,8 @@ __SC_INNER_IMPORT__
           Returns="@(_SponsorCheck_CoveredShallow___SC_PACKAGE_ID__)">
     <ItemGroup>
       <_SponsorCheck_CoveredShallow___SC_PACKAGE_ID__
-          Include="$(_SponsorCheck_ThePackageId)"
-          Condition="@(PackageReference->AnyHaveMetadataValue('Identity', '$(_SponsorCheck_ThePackageId)'))" />
+          Include="$(_SponsorCheck___SC_PACKAGE_ID___ThePackageId)"
+          Condition="@(PackageReference->AnyHaveMetadataValue('Identity', '$(_SponsorCheck___SC_PACKAGE_ID___ThePackageId)'))" />
     </ItemGroup>
   </Target>
 
@@ -61,8 +71,8 @@ __SC_INNER_IMPORT__
     </MSBuild>
 
     <ItemGroup>
-      <_SponsorCheck___SC_PACKAGE_ID___Ref Include="@(PackageReference)" Condition="'%(Identity)' == '$(_SponsorCheck_ThePackageId)'" />
-      <_SponsorCheck___SC_PACKAGE_ID___Ver Include="@(PackageVersion)"   Condition="'%(Identity)' == '$(_SponsorCheck_ThePackageId)'" />
+      <_SponsorCheck___SC_PACKAGE_ID___Ref Include="@(PackageReference)" Condition="'%(Identity)' == '$(_SponsorCheck___SC_PACKAGE_ID___ThePackageId)'" />
+      <_SponsorCheck___SC_PACKAGE_ID___Ver Include="@(PackageVersion)"   Condition="'%(Identity)' == '$(_SponsorCheck___SC_PACKAGE_ID___ThePackageId)'" />
     </ItemGroup>
 
     <!-- Flatten item-metadata into properties first so MSBuild doesn't task-batch. See SponsorCheck.targets for the full explanation. -->
@@ -89,14 +99,14 @@ __SC_INNER_IMPORT__
 
     <__SC_TASK_NAME__
         Condition="'@(_SponsorCheck_RefCovers___SC_PACKAGE_ID__)' == ''"
-        ThePackageId="$(_SponsorCheck_ThePackageId)"
-        SponsorHashListPath="$(_SponsorCheck_HashListPath)"
-        PackDatePath="$(_SponsorCheck_PackDatePath)"
-        AuthorAccountsPath="$(_SponsorCheck_AuthorAccountsPath)"
-        SeverityOverridesPath="$(_SponsorCheck_SeverityOverridesPath)"
-        MessageOverridesPath="$(_SponsorCheck_MessageOverridesPath)"
-        LandingUrlPath="$(_SponsorCheck_LandingUrlPath)"
-        ExemptionsPath="$(_SponsorCheck_ExemptionsPath)"
+        ThePackageId="$(_SponsorCheck___SC_PACKAGE_ID___ThePackageId)"
+        SponsorHashListPath="$(_SponsorCheck___SC_PACKAGE_ID___HashListPath)"
+        PackDatePath="$(_SponsorCheck___SC_PACKAGE_ID___PackDatePath)"
+        AuthorAccountsPath="$(_SponsorCheck___SC_PACKAGE_ID___AuthorAccountsPath)"
+        SeverityOverridesPath="$(_SponsorCheck___SC_PACKAGE_ID___SeverityOverridesPath)"
+        MessageOverridesPath="$(_SponsorCheck___SC_PACKAGE_ID___MessageOverridesPath)"
+        LandingUrlPath="$(_SponsorCheck___SC_PACKAGE_ID___LandingUrlPath)"
+        ExemptionsPath="$(_SponsorCheck___SC_PACKAGE_ID___ExemptionsPath)"
         IsCpm="$(ManagePackageVersionsCentrally)"
         ConsumerProjectPath="$(MSBuildProjectFullPath)"
         DirectoryPackagesPropsPath="$(DirectoryPackagesPropsPath)"

--- a/src/SponsorCheck/EmbeddedTemplates/ConsumerVerifierOwner.targets
+++ b/src/SponsorCheck/EmbeddedTemplates/ConsumerVerifierOwner.targets
@@ -1,23 +1,34 @@
 <Project>
 __SC_INNER_IMPORT__
+  <!-- Every property here is scoped to the package it ships in, because this file is imported
+       once per package — owner mode still emits one verifier per package — and MSBuild
+       properties are global. An unscoped name is written by each import in turn and the last
+       one wins for the whole project, so two of these files would share one set
+       of paths: each verifier would read another package's sponsor list, exemptions and task
+       assembly. The task-name collision below is the same problem — this is the rest of it.
+
+       The clobbered TasksDir also reached the *authoring* side. A package whose author references
+       another SponsorCheck package packs `$(TasksDir)netstandard2.0\*.dll` into its own nupkg, so
+       it shipped whichever SponsorCheck the other package bundled — a stale task in a package
+       whose restore was correct, failing only for its consumers. -->
   <PropertyGroup>
-    <_SponsorCheck_ThePackageId>__SC_PACKAGE_ID_RAW__</_SponsorCheck_ThePackageId>
-    <_SponsorCheck_OwnerId>__SC_OWNER_ID_RAW__</_SponsorCheck_OwnerId>
-    <_SponsorCheck_TasksDir>$(MSBuildThisFileDirectory)..\tasks\</_SponsorCheck_TasksDir>
-    <_SponsorCheck_TasksAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(_SponsorCheck_TasksDir)netstandard2.0\SponsorCheck.dll</_SponsorCheck_TasksAssembly>
-    <_SponsorCheck_TasksAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(_SponsorCheck_TasksDir)net472\SponsorCheck.dll</_SponsorCheck_TasksAssembly>
-    <_SponsorCheck_HashListPath>$(MSBuildThisFileDirectory)SponsorCheck.SponsorHashes.txt</_SponsorCheck_HashListPath>
-    <_SponsorCheck_PackDatePath>$(MSBuildThisFileDirectory)SponsorCheck.PackDate.txt</_SponsorCheck_PackDatePath>
-    <_SponsorCheck_AuthorAccountsPath>$(MSBuildThisFileDirectory)SponsorCheck.AuthorAccounts.txt</_SponsorCheck_AuthorAccountsPath>
-    <_SponsorCheck_SeverityOverridesPath>$(MSBuildThisFileDirectory)SponsorCheck.SeverityOverrides.txt</_SponsorCheck_SeverityOverridesPath>
-    <_SponsorCheck_MessageOverridesPath>$(MSBuildThisFileDirectory)SponsorCheck.MessageOverrides.json</_SponsorCheck_MessageOverridesPath>
-    <_SponsorCheck_LandingUrlPath>$(MSBuildThisFileDirectory)SponsorCheck.LandingUrl.txt</_SponsorCheck_LandingUrlPath>
-    <_SponsorCheck_ExemptionsPath>$(MSBuildThisFileDirectory)SponsorCheck.Exemptions.json</_SponsorCheck_ExemptionsPath>
+    <_SponsorCheck___SC_PACKAGE_ID___ThePackageId>__SC_PACKAGE_ID_RAW__</_SponsorCheck___SC_PACKAGE_ID___ThePackageId>
+    <_SponsorCheck___SC_PACKAGE_ID___OwnerId>__SC_OWNER_ID_RAW__</_SponsorCheck___SC_PACKAGE_ID___OwnerId>
+    <_SponsorCheck___SC_PACKAGE_ID___TasksDir>$(MSBuildThisFileDirectory)..\tasks\</_SponsorCheck___SC_PACKAGE_ID___TasksDir>
+    <_SponsorCheck___SC_PACKAGE_ID___TasksAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(_SponsorCheck___SC_PACKAGE_ID___TasksDir)netstandard2.0\SponsorCheck.dll</_SponsorCheck___SC_PACKAGE_ID___TasksAssembly>
+    <_SponsorCheck___SC_PACKAGE_ID___TasksAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(_SponsorCheck___SC_PACKAGE_ID___TasksDir)net472\SponsorCheck.dll</_SponsorCheck___SC_PACKAGE_ID___TasksAssembly>
+    <_SponsorCheck___SC_PACKAGE_ID___HashListPath>$(MSBuildThisFileDirectory)SponsorCheck.SponsorHashes.txt</_SponsorCheck___SC_PACKAGE_ID___HashListPath>
+    <_SponsorCheck___SC_PACKAGE_ID___PackDatePath>$(MSBuildThisFileDirectory)SponsorCheck.PackDate.txt</_SponsorCheck___SC_PACKAGE_ID___PackDatePath>
+    <_SponsorCheck___SC_PACKAGE_ID___AuthorAccountsPath>$(MSBuildThisFileDirectory)SponsorCheck.AuthorAccounts.txt</_SponsorCheck___SC_PACKAGE_ID___AuthorAccountsPath>
+    <_SponsorCheck___SC_PACKAGE_ID___SeverityOverridesPath>$(MSBuildThisFileDirectory)SponsorCheck.SeverityOverrides.txt</_SponsorCheck___SC_PACKAGE_ID___SeverityOverridesPath>
+    <_SponsorCheck___SC_PACKAGE_ID___MessageOverridesPath>$(MSBuildThisFileDirectory)SponsorCheck.MessageOverrides.json</_SponsorCheck___SC_PACKAGE_ID___MessageOverridesPath>
+    <_SponsorCheck___SC_PACKAGE_ID___LandingUrlPath>$(MSBuildThisFileDirectory)SponsorCheck.LandingUrl.txt</_SponsorCheck___SC_PACKAGE_ID___LandingUrlPath>
+    <_SponsorCheck___SC_PACKAGE_ID___ExemptionsPath>$(MSBuildThisFileDirectory)SponsorCheck.Exemptions.json</_SponsorCheck___SC_PACKAGE_ID___ExemptionsPath>
   </PropertyGroup>
 
   <!-- Version-scoped task name — see ConsumerVerifier.targets for why the bare name can't be used. -->
   <UsingTask TaskName="__SC_TASK_NAME__"
-             AssemblyFile="$(_SponsorCheck_TasksAssembly)" />
+             AssemblyFile="$(_SponsorCheck___SC_PACKAGE_ID___TasksAssembly)" />
 
   <!-- Project-reference coverage responders. When a transitive consumer (this project's verifier
        was imported via buildTransitive/) has a sibling ProjectReference that already covers
@@ -31,8 +42,8 @@ __SC_INNER_IMPORT__
           Returns="@(_SponsorCheck_Covered___SC_PACKAGE_ID__)">
     <ItemGroup>
       <_SponsorCheck_Covered___SC_PACKAGE_ID__
-          Include="$(_SponsorCheck_ThePackageId)"
-          Condition="@(PackageReference->AnyHaveMetadataValue('Identity', '$(_SponsorCheck_ThePackageId)'))" />
+          Include="$(_SponsorCheck___SC_PACKAGE_ID___ThePackageId)"
+          Condition="@(PackageReference->AnyHaveMetadataValue('Identity', '$(_SponsorCheck___SC_PACKAGE_ID___ThePackageId)'))" />
     </ItemGroup>
     <MSBuild Projects="@(ProjectReference)"
              Targets="_SponsorCheck_CoversShallow___SC_PACKAGE_ID__"
@@ -46,8 +57,8 @@ __SC_INNER_IMPORT__
           Returns="@(_SponsorCheck_CoveredShallow___SC_PACKAGE_ID__)">
     <ItemGroup>
       <_SponsorCheck_CoveredShallow___SC_PACKAGE_ID__
-          Include="$(_SponsorCheck_ThePackageId)"
-          Condition="@(PackageReference->AnyHaveMetadataValue('Identity', '$(_SponsorCheck_ThePackageId)'))" />
+          Include="$(_SponsorCheck___SC_PACKAGE_ID___ThePackageId)"
+          Condition="@(PackageReference->AnyHaveMetadataValue('Identity', '$(_SponsorCheck___SC_PACKAGE_ID___ThePackageId)'))" />
     </ItemGroup>
   </Target>
 
@@ -72,15 +83,15 @@ __SC_INNER_IMPORT__
 
     <__SC_TASK_NAME__
         Condition="'@(_SponsorCheck_RefCovers___SC_PACKAGE_ID__)' == ''"
-        ThePackageId="$(_SponsorCheck_ThePackageId)"
-        OwnerId="$(_SponsorCheck_OwnerId)"
-        SponsorHashListPath="$(_SponsorCheck_HashListPath)"
-        PackDatePath="$(_SponsorCheck_PackDatePath)"
-        AuthorAccountsPath="$(_SponsorCheck_AuthorAccountsPath)"
-        SeverityOverridesPath="$(_SponsorCheck_SeverityOverridesPath)"
-        MessageOverridesPath="$(_SponsorCheck_MessageOverridesPath)"
-        LandingUrlPath="$(_SponsorCheck_LandingUrlPath)"
-        ExemptionsPath="$(_SponsorCheck_ExemptionsPath)"
+        ThePackageId="$(_SponsorCheck___SC_PACKAGE_ID___ThePackageId)"
+        OwnerId="$(_SponsorCheck___SC_PACKAGE_ID___OwnerId)"
+        SponsorHashListPath="$(_SponsorCheck___SC_PACKAGE_ID___HashListPath)"
+        PackDatePath="$(_SponsorCheck___SC_PACKAGE_ID___PackDatePath)"
+        AuthorAccountsPath="$(_SponsorCheck___SC_PACKAGE_ID___AuthorAccountsPath)"
+        SeverityOverridesPath="$(_SponsorCheck___SC_PACKAGE_ID___SeverityOverridesPath)"
+        MessageOverridesPath="$(_SponsorCheck___SC_PACKAGE_ID___MessageOverridesPath)"
+        LandingUrlPath="$(_SponsorCheck___SC_PACKAGE_ID___LandingUrlPath)"
+        ExemptionsPath="$(_SponsorCheck___SC_PACKAGE_ID___ExemptionsPath)"
         ConsumerProjectPath="$(MSBuildProjectFullPath)"
         IgnoredFromRef="$(__SC_OWNER_PREFIX__SponsorshipLicenseIgnored)"
         LicensedUntilFromRef="$(__SC_OWNER_PREFIX__SponsorshipLicensedUntil)"


### PR DESCRIPTION
A generated verifier is imported once per package, and MSBuild properties are global. The paths were unscoped names — TasksDir, TasksAssembly, HashListPath, the sidecars — so each import wrote them in turn and the last one won for the whole project. Two SponsorCheck packages in one project therefore shared a single set: each verifier read the other's sponsor list, exemptions and task assembly. Version-scoping the task name fixed half of this; these are the rest.

The clobbered TasksDir also reached the authoring side, which is how it surfaced. A package whose author references another SponsorCheck package packs $(TasksDir)netstandard2.0\*.dll into its own nupkg, so it shipped whichever SponsorCheck the dependency bundled. Parchment.Morph 6.2.2 went out carrying 0.16.0 from the Morph package while its own restore resolved 0.19.0 — a stale task in a package whose build was correct, failing only for its consumers, and only once a newer verifier passed a parameter the old task did not declare.

Owner mode scopes by package too. It emits one verifier per package and the paths are relative to each file, so scoping those by owner would leave every package from one owner sharing them — which is exactly the pair that broke. Only the run-once guard stays owner-scoped: sharing it is what makes N packages from one owner verify once.